### PR TITLE
Supply pause bug

### DIFF
--- a/globalcombined.lua
+++ b/globalcombined.lua
@@ -64,6 +64,7 @@ function et_ClientCommand(cno,cmd)
 	if cmd == "pause"
 		et.trap_SendServerCommand( cno , "print \"Pause captured.\n\"" )
 		return 1
+	end
 
 
 if cmd == "forcetapout" then --forcetapout bugfix

--- a/globalcombined.lua
+++ b/globalcombined.lua
@@ -62,7 +62,7 @@ function et_ClientCommand(cno,cmd)
 		end
 	end
 
-	if cmd == "pause" and tonumber(et.trap_Cvar_Get("sv_maxclients")) == 1 then
+	if cmd == "pause" and tonumber(et.trap_Cvar_Get("pauselock")) == 1 then
 		et.trap_SendServerCommand( cno , "print \"Pause captured.\n\"" )
 		return 1
 	end

--- a/globalcombined.lua
+++ b/globalcombined.lua
@@ -61,6 +61,10 @@ function et_ClientCommand(cno,cmd)
 			return 1
 		end
 	end
+	if cmd == "pause"
+		et.trap_SendServerCommand( cno , "print \"Pause captured.\n\"" )
+		return 1
+
 
 if cmd == "forcetapout" then --forcetapout bugfix
 	if et.gentity_get(cno, "r.contents") == 0 then  --contents 0 =nobody

--- a/globalcombined.lua
+++ b/globalcombined.lua
@@ -63,7 +63,7 @@ function et_ClientCommand(cno,cmd)
 	end
 
 	if cmd == "pause" and tonumber(et.trap_Cvar_Get("pauselock")) == 1 then
-		et.trap_SendServerCommand( cno , "print \"Pause captured.\n\"" )
+		et.trap_SendServerCommand( cno , "print \"Pause forbidden during this stage of the map.\n\"" )
 		return 1
 	end
 

--- a/globalcombined.lua
+++ b/globalcombined.lua
@@ -62,7 +62,7 @@ function et_ClientCommand(cno,cmd)
 		end
 	end
 
-	if cmd == "pause" then
+	if cmd == "pause" and tonumber(et.trap_Cvar_Get("sv_maxclients")) == 1 then
 		et.trap_SendServerCommand( cno , "print \"Pause captured.\n\"" )
 		return 1
 	end

--- a/globalcombined.lua
+++ b/globalcombined.lua
@@ -56,12 +56,13 @@ function et_ClientCommand(cno,cmd)
 			et.trap_SendServerCommand( cno , "print \"Invalid team join command.\n\"" )
 			return 1
 		end
-        if arg1 ~= "" and byte ~= 98 and byte ~= 114 and byte ~= 115 then 
+		if arg1 ~= "" and byte ~= 98 and byte ~= 114 and byte ~= 115 then 
 			et.trap_SendServerCommand( cno , "print \"Invalid team join command.\n\"" )
 			return 1
 		end
 	end
-	if cmd == "pause"
+
+	if cmd == "pause" then
 		et.trap_SendServerCommand( cno , "print \"Pause captured.\n\"" )
 		return 1
 	end

--- a/globalcombined.lua
+++ b/globalcombined.lua
@@ -33,6 +33,7 @@ function et_InitGame(levelTime,randomSeed,restart)
 		et.trap_Cvar_Set( "b_gameformat", "0" )
 	end
 
+	et.trap_Cvar_Set("pauselock", "0")
 end
 
 -- client command checks, formerly wsfix

--- a/globalmapscripts/supply.script
+++ b/globalmapscripts/supply.script
@@ -15,6 +15,7 @@ game_manager {
                 // mortis - roof clip
                 create
                 {
+cvar pauselock set 1
                         scriptName "bugfix1"
                         classname "func_fakebrush"
                         origin "1072 -1824 502"

--- a/globalmapscripts/supply.script
+++ b/globalmapscripts/supply.script
@@ -11,11 +11,12 @@
 
 game_manager {
         spawn {
+			cvar pauselock set 1
+
 
                 // mortis - roof clip
                 create
                 {
-cvar pauselock set 1
                         scriptName "bugfix1"
                         classname "func_fakebrush"
                         origin "1072 -1824 502"

--- a/globalmapscripts/supply.script
+++ b/globalmapscripts/supply.script
@@ -728,7 +728,7 @@ crane_enabler {
                 accum 2 abort_if_equal 0        //Abort if crane controls not built
                 accum 1 set 0                        //Only do the crane routine once!
 
-				cvar pauselock set 1 // Pause lock enabled
+                cvar pauselock set 1 // Pause lock enabled
                 wm_announce "The Allies have activated the crane!"
                 // *----------------------------------- vo ------------------------------------------*
                 wm_teamvoiceannounce 0 "axis_gold_taken"
@@ -797,7 +797,7 @@ crane_enabler {
 
                 //Let truck continue
                 trigger truck enable_stage3
-				cvar pauselock set 0 // Pause lock disabled
+                cvar pauselock set 0 // Pause lock disabled
                 wm_announce "The Allies have loaded the Gold Crate onto the Truck!"
                 setstate goldcrate invisible
             wait 100

--- a/globalmapscripts/supply.script
+++ b/globalmapscripts/supply.script
@@ -11,8 +11,6 @@
 
 game_manager {
         spawn {
-			cvar pauselock set 1
-
 
                 // mortis - roof clip
                 create
@@ -729,6 +727,8 @@ crane_enabler {
                 accum 1 abort_if_equal 0        //Abort if truck is not in place
                 accum 2 abort_if_equal 0        //Abort if crane controls not built
                 accum 1 set 0                        //Only do the crane routine once!
+
+				cvar pauselock set 1 // Pause lock enabled
                 wm_announce "The Allies have activated the crane!"
                 // *----------------------------------- vo ------------------------------------------*
                 wm_teamvoiceannounce 0 "axis_gold_taken"
@@ -797,6 +797,7 @@ crane_enabler {
 
                 //Let truck continue
                 trigger truck enable_stage3
+				cvar pauselock set 0 // Pause lock disabled
                 wm_announce "The Allies have loaded the Gold Crate onto the Truck!"
                 setstate goldcrate invisible
             wait 100


### PR DESCRIPTION
This change adds a cvar `pauselock`. When a user tried to pause and `pauselock` is `1`, the server will refuse to pause and return a message.

In the mapscript, `pauselock` is set to `1` at the time sensitive stage, and back to `0` once it is over. This addition should work on any map.

Fixes #4
