### PR TITLE
Remove oasis

### DIFF
--- a/configs/global3.config
+++ b/configs/global3.config
@@ -243,14 +243,6 @@ map sw_goldrush_te
     mapscripthash {{ sha1:mapscripts/sw_goldrush_te.script }}
 }
 
-map oasis
-{
-    set g_userTimeLimit 12
-    setl g_useralliedrespawntime 15
-    setl g_useraxisrespawntime 30
-    mapscripthash {{ sha1:mapscripts/oasis.script }}
-}
-
 map sw_oasis_b3
 {
     set g_userTimeLimit 12

--- a/configs/global5.config
+++ b/configs/global5.config
@@ -240,14 +240,6 @@ map sw_goldrush_te
     mapscripthash {{ sha1:mapscripts/sw_goldrush_te.script }}
 }
 
-map oasis
-{
-    set g_userTimeLimit 20
-    setl g_useralliedrespawntime 15
-    setl g_useraxisrespawntime 30
-    mapscripthash {{ sha1:mapscripts/oasis.script }}
-}
-
 map sw_oasis_b3
 {
     set g_userTimeLimit 15

--- a/configs/global6.config
+++ b/configs/global6.config
@@ -241,14 +241,6 @@ map sw_goldrush_te
     mapscripthash {{ sha1:mapscripts/sw_goldrush_te.script }}
 }
 
-map oasis
-{
-    set g_userTimeLimit 20
-    setl g_useralliedrespawntime 15
-    setl g_useraxisrespawntime 30
-    mapscripthash {{ sha1:mapscripts/oasis.script }}
-}
-
 map sw_oasis_b3
 {
     set g_userTimeLimit 15


### PR DESCRIPTION
The old configs referred to a mapscript which can not be found anywhere. I think it's best to simply remove oasis as it has not been used in competition for at least the 8 years I have been around.

Fixes #6 
